### PR TITLE
fix

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -162,9 +162,10 @@ module AnsibleSpec
     host['name'] = line
     host['port'] = 22
     host['connection'] = "ssh"
-    if line.include?(":") # 192.168.0.1:22
-      host['uri']  = line.split(":")[0]
-      host['port'] = line.split(":")[1].to_i
+    target = line.split[0]
+    if target.include?(":") # 192.168.0.1:22
+      host['uri']  = target.split(":")[0]
+      host['port'] = target.split(":")[1].to_i
       return host
     end
     # 192.168.0.1 ansible_ssh_port=22

--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -36,6 +36,7 @@ module AnsibleSpec
 
       # get group
       if line.start_with?('[') && line.end_with?(']')
+        next if line.end_with?(':vars]')  # group variables
         group = line.gsub('[','').gsub(']','')
         groups["#{group}"] = Array.new
         next


### PR DESCRIPTION
1. 以下のように変数で ":" が使われている場合に uri が正しく設定されない問題の修正
```
hostname hoge=192.168.0.100:80
```

2. inventory の :vars セクションをスキップし、グループとして扱わない

https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#defining-variables-in-ini-format