### PR TITLE
Modify resolve_variables method

### DIFF
--- a/spec/case/get_variable/resolve_variables/group_vars/all.yml
+++ b/spec/case/get_variable/resolve_variables/group_vars/all.yml
@@ -18,6 +18,16 @@ var_nested_array_hash_1: 'val_array_hash'
 var_nested_array_hash_2:
   - key: "{{ var_nested_array_hash_1 }}"
 
+var_array_concat_1:
+  - "val_array"
+var_array_concat_2: "{{ var_array_concat_1 + var_array_concat_1 }}"
+
+var_array_merge_1:
+  key1: "val_hash_1"
+var_array_merge_2:
+  key2: "val_hash_2"
+var_array_merge_3: "{{ var_array_merge_1 + var_array_merge_2 }}"
+
 var_nested_whitespace_1: val_nested_whitespace
 var_nested_whitespace_2: "{{var_nested_whitespace_1  }}"
 

--- a/spec/get_variable_spec.rb
+++ b/spec/get_variable_spec.rb
@@ -450,7 +450,7 @@ describe "get_hash_behaviourの実行" do
     end
   
     it 'exist fourteen pairs in Hash' do
-      expect(@res.length).to eq 14
+      expect(@res.length).to eq 19
     end
   
     it 'exist all pairs' do
@@ -465,6 +465,11 @@ describe "get_hash_behaviourの実行" do
       expect(@res).to include({'var_nested_array_2' => ['val_array']})
       expect(@res).to include({'var_nested_array_hash_1' => 'val_array_hash'})
       expect(@res).to include({'var_nested_array_hash_2' => [{'key' => 'val_array_hash'}]})
+      expect(@res).to include({'var_array_concat_1' => ['val_array']})
+      expect(@res).to include({'var_array_concat_2' => ['val_array', 'val_array']})
+      expect(@res).to include({'var_array_merge_1' => {'key1'=>'val_hash_1'}})
+      expect(@res).to include({'var_array_merge_2' => {'key2'=>'val_hash_2'}})
+      expect(@res).to include({'var_array_merge_3' => {'key1'=>'val_hash_1', 'key2'=>'val_hash_2'}})
       expect(@res).to include({'var_nested_whitespace_1' => 'val_nested_whitespace'})
       expect(@res).to include({'var_nested_whitespace_2' => 'val_nested_whitespace'})
       expect(@res).to include({'var_missingtarget_2' => '{{ var_missingtarget_1 }}'})


### PR DESCRIPTION
以下のような書き方に対応します。

```
{{ hoge + fuga }}
```

https://jinja.palletsprojects.com/en/3.1.x/templates/#math
jinja2 では + 以外にも様々なことができますが、簡単のため個人的にAnsibleでよく利用する + のみに対応させました。

```+``` が利用できると、たとえば以下のような使い方ができるようになります
```all.yml
_manage_expose_ports:
 - 22
expose_ports: "{{ _manage_expose_ports }}"
```
```webserver.yml
_web_expose_ports:
 - 80
 - 443
expose_ports: "{{ _manage_expose_ports + _web_expose_ports }}"
```

